### PR TITLE
feat: bump github.com/cosnicolaou/pbzip2 from 1.0.3 to 1.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.2
 toolchain go1.22.8
 
 require (
-	github.com/cosnicolaou/pbzip2 v1.0.3
+	github.com/cosnicolaou/pbzip2 v1.0.5
 	github.com/goccy/go-json v0.10.3
 	github.com/orisano/gosax v0.0.0-20241004185612-5b002aaa57b2
 	github.com/schollz/progressbar/v3 v3.16.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
 github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
-github.com/cosnicolaou/pbzip2 v1.0.3 h1:CebGEQSYOg9uFDfTgIXNDI3cuaQovlnBUcdB614dQws=
-github.com/cosnicolaou/pbzip2 v1.0.3/go.mod h1:uCNfm0iE2wIKGRlLyq31M4toziFprNhEnvueGmh5u3M=
+github.com/cosnicolaou/pbzip2 v1.0.5 h1:+PZ8yRBx6bRXncOJWQvEThyFm8XhF9Yb6WUMN6KsgrA=
+github.com/cosnicolaou/pbzip2 v1.0.5/go.mod h1:uCNfm0iE2wIKGRlLyq31M4toziFprNhEnvueGmh5u3M=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=


### PR DESCRIPTION
As the developer of gosax, I was analyzing its performance in real-world workloads when I came across this repository. While investigating, I discovered that in your use case, the performance bottleneck wasn't actually in gosax itself, but in the pbzip2 library.

## Performance Improvement
After identifying this bottleneck, I focused on optimizing pbzip2 and managed to achieve a 40% performance improvement. This optimization has been released as pbzip2 v1.0.5.

## Changes

Update pbzip2 dependency to v1.0.5

Thank you for using gosax in a real world - it's through real-world usage like this that we can identify and address performance bottlenecks in the entire processing pipeline.
